### PR TITLE
feat(slack): add users get command and JSON output support

### DIFF
--- a/internal/adapters/slack/client.go
+++ b/internal/adapters/slack/client.go
@@ -45,10 +45,12 @@ type ClientConfig struct {
 }
 
 // DefaultConfig returns sensible defaults.
+// Rate limit is set to 20 requests/minute (Slack Tier 2 limit) with burst of 3.
+// See: https://docs.slack.dev/apis/web-api/rate-limits/
 func DefaultConfig() *ClientConfig {
 	return &ClientConfig{
-		RateLimit:    rate.Limit(1),
-		RateBurst:    1,
+		RateLimit:    rate.Limit(20.0 / 60.0), // 20 requests per minute = ~0.33/sec
+		RateBurst:    3,                        // Allow small burst for initial requests
 		UserCacheTTL: 5 * time.Minute,
 		Debug:        false,
 	}

--- a/internal/adapters/slack/client_errors_test.go
+++ b/internal/adapters/slack/client_errors_test.go
@@ -133,7 +133,7 @@ func TestNewClient_ConfigDefaults(t *testing.T) {
 				RateBurst:    5,
 				UserCacheTTL: 10 * time.Minute,
 			},
-			wantRateLimit:    1,
+			wantRateLimit:    20.0 / 60.0, // Default: 20 req/min
 			wantRateBurst:    5,
 			wantUserCacheTTL: 10 * time.Minute,
 		},
@@ -146,7 +146,7 @@ func TestNewClient_ConfigDefaults(t *testing.T) {
 				UserCacheTTL: 10 * time.Minute,
 			},
 			wantRateLimit:    2,
-			wantRateBurst:    1,
+			wantRateBurst:    3, // Default burst
 			wantUserCacheTTL: 10 * time.Minute,
 		},
 		{
@@ -334,8 +334,8 @@ func TestWaitForRateLimit_DeadlineExceeded(t *testing.T) {
 func TestDefaultConfig_Values(t *testing.T) {
 	config := DefaultConfig()
 
-	assert.Equal(t, float64(1), float64(config.RateLimit))
-	assert.Equal(t, 1, config.RateBurst)
+	assert.InDelta(t, 20.0/60.0, float64(config.RateLimit), 0.01) // 20 requests/minute
+	assert.Equal(t, 3, config.RateBurst)
 	assert.Equal(t, 5*time.Minute, config.UserCacheTTL)
 	assert.False(t, config.Debug)
 	assert.Empty(t, config.UserToken)

--- a/internal/adapters/slack/client_test.go
+++ b/internal/adapters/slack/client_test.go
@@ -19,8 +19,8 @@ import (
 func TestDefaultConfig(t *testing.T) {
 	config := DefaultConfig()
 
-	assert.Equal(t, float64(1), float64(config.RateLimit))
-	assert.Equal(t, 1, config.RateBurst)
+	assert.InDelta(t, 20.0/60.0, float64(config.RateLimit), 0.01) // 20 requests/minute
+	assert.Equal(t, 3, config.RateBurst)
 	assert.Equal(t, 5*time.Minute, config.UserCacheTTL)
 	assert.False(t, config.Debug)
 	assert.Empty(t, config.UserToken)

--- a/internal/adapters/slack/converters.go
+++ b/internal/adapters/slack/converters.go
@@ -87,18 +87,33 @@ func convertChannel(ch slack.Channel) domain.SlackChannel {
 
 // convertUser converts slack-go User to domain.SlackUser.
 func convertUser(u slack.User) domain.SlackUser {
-	return domain.SlackUser{
+	user := domain.SlackUser{
 		ID:          u.ID,
 		Name:        u.Name,
 		RealName:    u.RealName,
 		DisplayName: u.Profile.DisplayName,
+		Title:       u.Profile.Title,
 		Email:       u.Profile.Email,
+		Phone:       u.Profile.Phone,
 		Avatar:      u.Profile.Image72,
 		IsBot:       u.IsBot,
 		IsAdmin:     u.IsAdmin,
 		Status:      u.Profile.StatusText,
+		StatusEmoji: u.Profile.StatusEmoji,
 		Timezone:    u.TZ,
 	}
+
+	// Extract custom profile fields (Department, Location, Start Date, etc.)
+	if fields := u.Profile.Fields.ToMap(); len(fields) > 0 {
+		user.CustomFields = make(map[string]string)
+		for _, field := range fields {
+			if field.Label != "" && field.Value != "" {
+				user.CustomFields[field.Label] = field.Value
+			}
+		}
+	}
+
+	return user
 }
 
 // convertReactions converts slack-go reactions to domain type.

--- a/internal/cli/slack/auth.go
+++ b/internal/cli/slack/auth.go
@@ -105,6 +105,14 @@ func newAuthStatusCmd() *cobra.Command {
 				return common.NewUserError("authentication failed", "Token may have expired or been revoked")
 			}
 
+			// Handle structured output (JSON/YAML/quiet)
+			format, _ := cmd.Flags().GetString("format")
+			quiet, _ := cmd.Flags().GetBool("quiet")
+			if common.IsJSON(cmd) || format == "yaml" || quiet {
+				out := common.GetOutputWriter(cmd)
+				return out.Write(auth)
+			}
+
 			_, _ = common.Green.Println("✓ Authenticated with Slack")
 			fmt.Println()
 			fmt.Printf("  User:      %s\n", common.Cyan.Sprint(auth.UserName))

--- a/internal/cli/slack/channel_info.go
+++ b/internal/cli/slack/channel_info.go
@@ -34,6 +34,14 @@ func newChannelInfoCmd() *cobra.Command {
 				return common.WrapGetError("channel", err)
 			}
 
+			// Handle structured output (JSON/YAML/quiet)
+			format, _ := cmd.Flags().GetString("format")
+			quiet, _ := cmd.Flags().GetBool("quiet")
+			if common.IsJSON(cmd) || format == "yaml" || quiet {
+				out := common.GetOutputWriter(cmd)
+				return out.Write(ch)
+			}
+
 			_, _ = common.Cyan.Printf("Channel: #%s\n", ch.Name)
 			fmt.Printf("  ID:           %s\n", ch.ID)
 			fmt.Printf("  Is Channel:   %v\n", ch.IsChannel)

--- a/internal/cli/slack/channels.go
+++ b/internal/cli/slack/channels.go
@@ -162,6 +162,14 @@ Examples:
 				return nil
 			}
 
+			// Handle structured output (JSON/YAML/quiet)
+			format, _ := cmd.Flags().GetString("format")
+			quiet, _ := cmd.Flags().GetBool("quiet")
+			if common.IsJSON(cmd) || format == "yaml" || quiet {
+				out := common.GetOutputWriter(cmd)
+				return out.Write(allChannels)
+			}
+
 			printChannels(allChannels, showID)
 
 			return nil

--- a/internal/cli/slack/files.go
+++ b/internal/cli/slack/files.go
@@ -123,6 +123,14 @@ Examples:
 				return nil
 			}
 
+			// Handle structured output (JSON/YAML/quiet)
+			format, _ := cmd.Flags().GetString("format")
+			quiet, _ := cmd.Flags().GetBool("quiet")
+			if common.IsJSON(cmd) || format == "yaml" || quiet {
+				out := common.GetOutputWriter(cmd)
+				return out.Write(resp.Files)
+			}
+
 			fmt.Printf("Found %d file(s):\n\n", len(resp.Files))
 			fmt.Println(strings.Repeat("─", 70))
 
@@ -199,6 +207,14 @@ func newFilesShowCmd() *cobra.Command {
 			file, err := client.GetFileInfo(ctx, fileID)
 			if err != nil {
 				return common.WrapGetError("file info", err)
+			}
+
+			// Handle structured output (JSON/YAML/quiet)
+			format, _ := cmd.Flags().GetString("format")
+			quiet, _ := cmd.Flags().GetBool("quiet")
+			if common.IsJSON(cmd) || format == "yaml" || quiet {
+				out := common.GetOutputWriter(cmd)
+				return out.Write(file)
 			}
 
 			fmt.Println(strings.Repeat("─", 60))

--- a/internal/cli/slack/messages.go
+++ b/internal/cli/slack/messages.go
@@ -143,6 +143,14 @@ Examples:
 				return nil
 			}
 
+			// Handle structured output (JSON/YAML/quiet) - before enrichment for performance
+			format, _ := cmd.Flags().GetString("format")
+			quiet, _ := cmd.Flags().GetBool("quiet")
+			if common.IsJSON(cmd) || format == "yaml" || quiet {
+				out := common.GetOutputWriter(cmd)
+				return out.Write(allMessages)
+			}
+
 			slackClient, isSlackClient := client.(*slack.Client)
 			if isSlackClient {
 				if err := slackClient.GetUsersForMessages(ctx, allMessages); err != nil {

--- a/internal/cli/slack/search.go
+++ b/internal/cli/slack/search.go
@@ -64,6 +64,14 @@ Examples:
 				return nil
 			}
 
+			// Handle structured output (JSON/YAML/quiet)
+			format, _ := cmd.Flags().GetString("format")
+			quiet, _ := cmd.Flags().GetBool("quiet")
+			if common.IsJSON(cmd) || format == "yaml" || quiet {
+				out := common.GetOutputWriter(cmd)
+				return out.Write(messages)
+			}
+
 			_, _ = common.Cyan.Printf("Found %d messages:\n\n", len(messages))
 
 			for _, msg := range messages {

--- a/internal/cli/slack/users.go
+++ b/internal/cli/slack/users.go
@@ -3,11 +3,14 @@
 package slack
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/mqasimca/nylas/internal/cli/common"
+	"github.com/mqasimca/nylas/internal/ports"
 )
 
 // newUsersCmd creates the users command for managing workspace users.
@@ -20,6 +23,7 @@ func newUsersCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newUserListCmd())
+	cmd.AddCommand(newUserGetCmd())
 
 	return cmd
 }
@@ -68,6 +72,14 @@ Examples:
 				return nil
 			}
 
+			// Handle structured output (JSON/YAML/quiet)
+			format, _ := cmd.Flags().GetString("format")
+			quiet, _ := cmd.Flags().GetBool("quiet")
+			if common.IsJSON(cmd) || format == "yaml" || quiet {
+				out := common.GetOutputWriter(cmd)
+				return out.Write(resp.Users)
+			}
+
 			for _, u := range resp.Users {
 				name := u.BestDisplayName()
 				fmt.Print(common.Cyan.Sprint(name))
@@ -106,4 +118,163 @@ Examples:
 	cmd.Flags().BoolVar(&showID, "id", false, "Show user IDs")
 
 	return cmd
+}
+
+// newUserGetCmd creates the get subcommand for retrieving a single user's details.
+func newUserGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <user-id>",
+		Short: "Get detailed user information",
+		Long: `Get detailed information about a Slack user including email and profile.
+
+Examples:
+  # Get user by ID
+  nylas slack users get UXXXXXXXX
+
+  # Get user by username (searches for match)
+  nylas slack users get @username`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := getSlackClientFromKeyring()
+			if err != nil {
+				return common.NewUserError(
+					"not authenticated with Slack",
+					"Run: nylas slack auth set --token YOUR_TOKEN",
+				)
+			}
+
+			ctx, cancel := common.CreateContext()
+			defer cancel()
+
+			userArg := args[0]
+
+			// If it looks like a username (@name or just name), search for the user
+			var userID string
+			if !isUserID(userArg) {
+				foundID, err := findUserIDByName(ctx, client, userArg)
+				if err != nil {
+					return err
+				}
+				userID = foundID
+			} else {
+				userID = userArg
+			}
+
+			user, err := client.GetUser(ctx, userID)
+			if err != nil {
+				return common.WrapGetError("user", err)
+			}
+
+			// Handle structured output (JSON/YAML/quiet)
+			format, _ := cmd.Flags().GetString("format")
+			quiet, _ := cmd.Flags().GetBool("quiet")
+			if common.IsJSON(cmd) || format == "yaml" || quiet {
+				out := common.GetOutputWriter(cmd)
+				return out.Write(user)
+			}
+
+			// Display user info (table format)
+			fmt.Println()
+			fmt.Println(common.Cyan.Sprint(user.BestDisplayName()))
+
+			if user.Title != "" {
+				printField("Title", user.Title)
+			}
+			if user.Name != "" {
+				printField("Username", "@"+user.Name)
+			}
+			if user.RealName != "" && user.RealName != user.DisplayName {
+				printField("Real Name", user.RealName)
+			}
+			printField("User ID", user.ID)
+
+			if user.Email != "" {
+				printField("Email", user.Email)
+			} else {
+				printField("Email", common.Dim.Sprint("(not available - requires users:read.email scope)"))
+			}
+
+			if user.Phone != "" {
+				printField("Phone", user.Phone)
+			}
+
+			// Status with emoji
+			if user.Status != "" {
+				status := user.Status
+				if user.StatusEmoji != "" {
+					status = user.StatusEmoji + " " + status
+				}
+				printField("Status", status)
+			} else if user.StatusEmoji != "" {
+				printField("Status", user.StatusEmoji)
+			}
+
+			if user.Timezone != "" {
+				printField("Timezone", user.Timezone)
+			}
+
+			// Custom profile fields (Department, Location, etc.)
+			if len(user.CustomFields) > 0 {
+				for label, value := range user.CustomFields {
+					printField(label, value)
+				}
+			}
+
+			if user.Avatar != "" {
+				printField("Avatar", user.Avatar)
+			}
+
+			// Flags
+			var flags []string
+			if user.IsAdmin {
+				flags = append(flags, "admin")
+			}
+			if user.IsBot {
+				flags = append(flags, "bot")
+			}
+			if len(flags) > 0 {
+				printField("Flags", common.Yellow.Sprint(flags))
+			}
+
+			fmt.Println()
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+// isUserID checks if the string looks like a Slack user ID (starts with U).
+func isUserID(s string) bool {
+	return len(s) > 1 && s[0] == 'U'
+}
+
+// findUserIDByName searches for a user by username and returns their ID.
+func findUserIDByName(ctx context.Context, client ports.SlackClient, name string) (string, error) {
+	// Strip @ prefix if present
+	name = strings.TrimPrefix(name, "@")
+
+	resp, err := client.ListUsers(ctx, 500, "")
+	if err != nil {
+		return "", common.WrapListError("users", err)
+	}
+
+	for _, u := range resp.Users {
+		if strings.EqualFold(u.Name, name) ||
+			strings.EqualFold(u.DisplayName, name) ||
+			strings.EqualFold(u.RealName, name) {
+			return u.ID, nil
+		}
+	}
+
+	return "", common.NewUserError(
+		fmt.Sprintf("user '%s' not found", name),
+		"Use 'nylas slack users list' to see available users",
+	)
+}
+
+// printField prints a labeled field value.
+func printField(label, value string) {
+	_, _ = common.Dim.Printf("  %-12s", label+":")
+	fmt.Println(" " + value)
 }

--- a/internal/domain/slack.go
+++ b/internal/domain/slack.go
@@ -42,16 +42,20 @@ type SlackChannel struct {
 
 // SlackUser represents a Slack workspace member.
 type SlackUser struct {
-	ID          string `json:"id"`                 // User ID (e.g., "U1234567890")
-	Name        string `json:"name"`               // Username handle (e.g., "jsmith")
-	RealName    string `json:"real_name"`          // Full name from profile (e.g., "John Smith")
-	DisplayName string `json:"display_name"`       // Custom display name set by user (may be empty)
-	Email       string `json:"email,omitempty"`    // User's email address (requires users:read.email scope)
-	Avatar      string `json:"avatar,omitempty"`   // URL to user's profile image (72x72 pixels)
-	IsBot       bool   `json:"is_bot"`             // True if this is a bot user
-	IsAdmin     bool   `json:"is_admin"`           // True if user has admin privileges
-	Status      string `json:"status,omitempty"`   // Custom status text (e.g., "In a meeting")
-	Timezone    string `json:"timezone,omitempty"` // User's timezone in IANA format (e.g., "America/New_York")
+	ID           string            `json:"id"`                     // User ID (e.g., "U1234567890")
+	Name         string            `json:"name"`                   // Username handle (e.g., "jsmith")
+	RealName     string            `json:"real_name"`              // Full name from profile (e.g., "John Smith")
+	DisplayName  string            `json:"display_name"`           // Custom display name set by user (may be empty)
+	Title        string            `json:"title,omitempty"`        // Job title (e.g., "Software Engineer")
+	Email        string            `json:"email,omitempty"`        // User's email address (requires users:read.email scope)
+	Phone        string            `json:"phone,omitempty"`        // Phone number
+	Avatar       string            `json:"avatar,omitempty"`       // URL to user's profile image (72x72 pixels)
+	IsBot        bool              `json:"is_bot"`                 // True if this is a bot user
+	IsAdmin      bool              `json:"is_admin"`               // True if user has admin privileges
+	Status       string            `json:"status,omitempty"`       // Custom status text (e.g., "In a meeting")
+	StatusEmoji  string            `json:"status_emoji,omitempty"` // Status emoji (e.g., ":calendar:")
+	Timezone     string            `json:"timezone,omitempty"`     // User's timezone in IANA format (e.g., "America/New_York")
+	CustomFields map[string]string `json:"custom_fields,omitempty"` // Custom profile fields (label -> value)
 }
 
 // SlackAttachment represents a file attached to a message.


### PR DESCRIPTION
- Add `slack users get` command to view detailed user profiles
  - Supports lookup by user ID or username
  - Shows title, email, phone, department, and custom fields
  - Fetches full profile via users.profile.get API

- Add JSON/YAML/quiet output to all slack commands:
  - users list, users get
  - channels list, channels info
  - messages list
  - files list, files show
  - search
  - auth status

- Fix Slack API rate limiting:
  - Add rate limit wait before users.profile.get call
  - Lower default rate to 20 req/min (Slack Tier 2 limit)
  - Increase burst to 3 for initial requests

- Extend SlackUser domain model:
  - Add Title, Phone, StatusEmoji fields
  - Add CustomFields map for workspace-specific fields